### PR TITLE
Price bracketing patch

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -476,7 +476,7 @@ for idx, rows in owner_results.iterrows():
         and rows["range_max"] >= max_affordable_price
     ):
         owner_results.at[idx, "Percent of Units Affordable"] = (
-            max_affordable_price / rows["range_max"]
+            (max_affordable_price - rows["range_min"]) / (rows["range_max"] - rows["range_min"])
         )
     else:
         owner_results.at[idx, "Percent of Units Affordable"] = 0
@@ -491,7 +491,7 @@ for idx, rows in renter_results.iterrows():
         and rows["range_max"] >= max_affordable_rent
     ):
         renter_results.at[idx, "Percent of Units Affordable"] = (
-            max_affordable_rent / rows["range_max"]
+            (max_affordable_rent - rows["range_min"]) / (rows["range_max"] - rows["range_min"])
         )
     else:
         renter_results.at[idx, "Percent of Units Affordable"] = 0


### PR DESCRIPTION
Updated the logic that calculates the percent of units that are affordable at the top affordability bracket. This was not behaving as expected and produced higher than expected estimates, this now calculates the units within the top bracket by comparing the max price/rent and where this falls within the range compared to the maximum of the range.